### PR TITLE
AsynchronousMetrics: derive server thread metrics by protocol type, n…

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -2152,59 +2152,53 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
 #endif
 
     {
-        auto threads_get_metric_name_doc = [](const String & name) -> std::pair<const char *, const char *>
+        auto threads_get_metric_name_doc = [](ProtocolMetricsType type) -> std::pair<const char *, const char *>
         {
-            static std::map<String, std::pair<const char *, const char *>> metric_map =
+            switch (type)
             {
-                {"tcp_port", {"TCPThreads", "Number of threads in the server of the TCP protocol (without TLS)."}},
-                {"tcp_port_secure", {"TCPSecureThreads", "Number of threads in the server of the TCP protocol (with TLS)."}},
-                {"http_port", {"HTTPThreads", "Number of threads in the server of the HTTP interface (without TLS)."}},
-                {"https_port", {"HTTPSecureThreads", "Number of threads in the server of the HTTPS interface."}},
-                {"interserver_http_port", {"InterserverThreads", "Number of threads in the server of the replicas communication protocol (without TLS)."}},
-                {"interserver_https_port", {"InterserverSecureThreads", "Number of threads in the server of the replicas communication protocol (with TLS)."}},
-                {"mysql_port", {"MySQLThreads", "Number of threads in the server of the MySQL compatibility protocol."}},
-                {"postgresql_port", {"PostgreSQLThreads", "Number of threads in the server of the PostgreSQL compatibility protocol."}},
-                {"grpc_port", {"GRPCThreads", "Number of threads in the server of the GRPC protocol."}},
-                {"prometheus.port", {"PrometheusThreads", "Number of threads in the server of the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."}},
-                {"keeper_server.tcp_port", {"KeeperTCPThreads", "Number of threads in the server of the Keeper TCP protocol (without TLS)."}},
-                {"keeper_server.tcp_port_secure", {"KeeperTCPSecureThreads", "Number of threads in the server of the Keeper TCP protocol (with TLS)."}}
-            };
-            auto it = metric_map.find(name);
-            if (it == metric_map.end())
-                return { nullptr, nullptr };
-            return it->second;
+                case ProtocolMetricsType::TCP: return {"TCPThreads", "Number of threads in the server of the TCP protocol (without TLS)."};
+                case ProtocolMetricsType::TCP_SECURE: return {"TCPSecureThreads", "Number of threads in the server of the TCP protocol (with TLS)."};
+                case ProtocolMetricsType::HTTP: return {"HTTPThreads", "Number of threads in the server of the HTTP interface (without TLS)."};
+                case ProtocolMetricsType::HTTPS: return {"HTTPSecureThreads", "Number of threads in the server of the HTTPS interface."};
+                case ProtocolMetricsType::INTERSERVER_HTTP: return {"InterserverThreads", "Number of threads in the server of the replicas communication protocol (without TLS)."};
+                case ProtocolMetricsType::INTERSERVER_HTTPS: return {"InterserverSecureThreads", "Number of threads in the server of the replicas communication protocol (with TLS)."};
+                case ProtocolMetricsType::MYSQL: return {"MySQLThreads", "Number of threads in the server of the MySQL compatibility protocol."};
+                case ProtocolMetricsType::POSTGRESQL: return {"PostgreSQLThreads", "Number of threads in the server of the PostgreSQL compatibility protocol."};
+                case ProtocolMetricsType::GRPC: return {"GRPCThreads", "Number of threads in the server of the GRPC protocol."};
+                case ProtocolMetricsType::PROMETHEUS: return {"PrometheusThreads", "Number of threads in the server of the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."};
+                case ProtocolMetricsType::KEEPER_TCP: return {"KeeperTCPThreads", "Number of threads in the server of the Keeper TCP protocol (without TLS)."};
+                case ProtocolMetricsType::KEEPER_TCP_SECURE: return {"KeeperTCPSecureThreads", "Number of threads in the server of the Keeper TCP protocol (with TLS)."};
+                default: return { nullptr, nullptr };
+            }
         };
 
-        auto rejected_connections_get_metric_name_doc = [](const String & name) -> std::pair<const char *, const char *>
+        auto rejected_connections_get_metric_name_doc = [](ProtocolMetricsType type) -> std::pair<const char *, const char *>
         {
-            static std::map<String, std::pair<const char *, const char *>> metric_map =
-                {
-                    {"tcp_port", {"TCPRejectedConnections", "Number of rejected connections for the TCP protocol (without TLS)."}},
-                    {"tcp_port_secure", {"TCPSecureRejectedConnections", "Number of rejected connections for the TCP protocol (with TLS)."}},
-                    {"http_port", {"HTTPRejectedConnections", "Number of rejected connections for the HTTP interface (without TLS)."}},
-                    {"https_port", {"HTTPSecureRejectedConnections", "Number of rejected connections for the HTTPS interface."}},
-                    {"interserver_http_port", {"InterserverRejectedConnections", "Number of rejected connections for the replicas communication protocol (without TLS)."}},
-                    {"interserver_https_port", {"InterserverSecureRejectedConnections", "Number of rejected connections for the replicas communication protocol (with TLS)."}},
-                    {"mysql_port", {"MySQLRejectedConnections", "Number of rejected connections for the MySQL compatibility protocol."}},
-                    {"postgresql_port", {"PostgreSQLRejectedConnections", "Number of rejected connections for the PostgreSQL compatibility protocol."}},
-                    {"grpc_port", {"GRPCRejectedConnections", "Number of rejected connections for the GRPC protocol."}},
-                    {"prometheus.port", {"PrometheusRejectedConnections", "Number of rejected connections for the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."}},
-                    {"keeper_server.tcp_port", {"KeeperTCPRejectedConnections", "Number of rejected connections for the Keeper TCP protocol (without TLS)."}},
-                    {"keeper_server.tcp_port_secure", {"KeeperTCPSecureRejectedConnections", "Number of rejected connections for the Keeper TCP protocol (with TLS)."}}
-                };
-            auto it = metric_map.find(name);
-            if (it == metric_map.end())
-                return { nullptr, nullptr };
-            return it->second;
+            switch (type)
+            {
+                case ProtocolMetricsType::TCP: return {"TCPRejectedConnections", "Number of rejected connections for the TCP protocol (without TLS)."};
+                case ProtocolMetricsType::TCP_SECURE: return {"TCPSecureRejectedConnections", "Number of rejected connections for the TCP protocol (with TLS)."};
+                case ProtocolMetricsType::HTTP: return {"HTTPRejectedConnections", "Number of rejected connections for the HTTP interface (without TLS)."};
+                case ProtocolMetricsType::HTTPS: return {"HTTPSecureRejectedConnections", "Number of rejected connections for the HTTPS interface."};
+                case ProtocolMetricsType::INTERSERVER_HTTP: return {"InterserverRejectedConnections", "Number of rejected connections for the replicas communication protocol (without TLS)."};
+                case ProtocolMetricsType::INTERSERVER_HTTPS: return {"InterserverSecureRejectedConnections", "Number of rejected connections for the replicas communication protocol (with TLS)."};
+                case ProtocolMetricsType::MYSQL: return {"MySQLRejectedConnections", "Number of rejected connections for the MySQL compatibility protocol."};
+                case ProtocolMetricsType::POSTGRESQL: return {"PostgreSQLRejectedConnections", "Number of rejected connections for the PostgreSQL compatibility protocol."};
+                case ProtocolMetricsType::GRPC: return {"GRPCRejectedConnections", "Number of rejected connections for the GRPC protocol."};
+                case ProtocolMetricsType::PROMETHEUS: return {"PrometheusRejectedConnections", "Number of rejected connections for the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."};
+                case ProtocolMetricsType::KEEPER_TCP: return {"KeeperTCPRejectedConnections", "Number of rejected connections for the Keeper TCP protocol (without TLS)."};
+                case ProtocolMetricsType::KEEPER_TCP_SECURE: return {"KeeperTCPSecureRejectedConnections", "Number of rejected connections for the Keeper TCP protocol (with TLS)."};
+                default: return { nullptr, nullptr };
+            }
         };
 
         const auto server_metrics = protocol_server_metrics_func();
         for (const auto & server_metric : server_metrics)
         {
-            if (auto name_doc = threads_get_metric_name_doc(server_metric.port_name); name_doc.first != nullptr)
+            if (auto name_doc = threads_get_metric_name_doc(server_metric.protocol_type); name_doc.first != nullptr)
                 new_values[name_doc.first] = { server_metric.current_threads, name_doc.second };
 
-            if (auto name_doc = rejected_connections_get_metric_name_doc(server_metric.port_name); name_doc.first != nullptr)
+            if (auto name_doc = rejected_connections_get_metric_name_doc(server_metric.protocol_type); name_doc.first != nullptr)
                 new_values[name_doc.first] = { server_metric.rejected_connections, name_doc.second };
         }
     }

--- a/src/Common/AsynchronousMetrics.h
+++ b/src/Common/AsynchronousMetrics.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <unordered_map>
 
+#include <Common/ProtocolMetricsTypes.h>
 
 namespace Poco
 {
@@ -39,7 +40,7 @@ using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMet
 
 struct ProtocolServerMetrics
 {
-    String port_name;
+    ProtocolMetricsType protocol_type;
     size_t current_threads;
     size_t rejected_connections;
 };

--- a/src/Common/ProtocolMetricsTypes.h
+++ b/src/Common/ProtocolMetricsTypes.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace DB
+{
+
+/// Protocol categories used to expose thread/connection metrics.
+/// This is intentionally decoupled from configuration keys and server names.
+enum class ProtocolMetricsType
+{
+    UNKNOWN = 0,
+
+    // ClickHouse server protocols
+    TCP,
+    TCP_SECURE,
+    TCP_WITH_PROXY,
+    TCP_SSH,
+    HTTP,
+    HTTPS,
+    MYSQL,
+    POSTGRESQL,
+    GRPC,
+    ARROW_FLIGHT,
+    INTERSERVER_HTTP,
+    INTERSERVER_HTTPS,
+    PROMETHEUS,
+
+    // Keeper specific endpoints (exposed from clickhouse-server when Keeper is enabled)
+    KEEPER_TCP,
+    KEEPER_TCP_SECURE,
+};
+
+}
+
+
+

--- a/src/Server/ProtocolServerAdapter.cpp
+++ b/src/Server/ProtocolServerAdapter.cpp
@@ -31,12 +31,14 @@ ProtocolServerAdapter::ProtocolServerAdapter(
     const char * port_name_,
     const std::string & description_,
     std::unique_ptr<TCPServer> tcp_server_,
+    ProtocolMetricsType metrics_type_,
     bool supports_runtime_reconfiguration_)
     : listen_host(listen_host_)
     , port_name(port_name_)
     , description(description_)
     , impl(std::make_unique<TCPServerAdapterImpl>(std::move(tcp_server_)))
     , supports_runtime_reconfiguration(supports_runtime_reconfiguration_)
+    , metrics_type(metrics_type_)
 {
 }
 
@@ -69,12 +71,14 @@ ProtocolServerAdapter::ProtocolServerAdapter(
     const char * port_name_,
     const std::string & description_,
     std::unique_ptr<IGRPCServer> grpc_server_,
+    ProtocolMetricsType metrics_type_,
     bool supports_runtime_reconfiguration_)
     : listen_host(listen_host_)
     , port_name(port_name_)
     , description(description_)
     , impl(std::make_unique<GRPCServerAdapterImpl>(std::move(grpc_server_)))
     , supports_runtime_reconfiguration(supports_runtime_reconfiguration_)
+    , metrics_type(metrics_type_)
 {
 }
 #endif

--- a/src/Server/ProtocolServerAdapter.h
+++ b/src/Server/ProtocolServerAdapter.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 
+#include <Common/ProtocolMetricsTypes.h>
 
 namespace DB
 {
@@ -26,6 +27,7 @@ public:
         const char * port_name_,
         const std::string & description_,
         std::unique_ptr<TCPServer> tcp_server_,
+        ProtocolMetricsType metrics_type_,
         bool supports_runtime_reconfiguration_ = true);
 
 #if USE_GRPC
@@ -34,6 +36,7 @@ public:
         const char * port_name_,
         const std::string & description_,
         std::unique_ptr<IGRPCServer> grpc_server_,
+        ProtocolMetricsType metrics_type_,
         bool supports_runtime_reconfiguration_ = true);
 #endif
 
@@ -64,6 +67,8 @@ public:
 
     const std::string & getDescription() const { return description; }
 
+    ProtocolMetricsType getMetricsType() const { return metrics_type; }
+
 private:
     class Impl
     {
@@ -85,6 +90,7 @@ private:
     std::string description;
     std::unique_ptr<Impl> impl;
     bool supports_runtime_reconfiguration = true;
+    ProtocolMetricsType metrics_type = ProtocolMetricsType::UNKNOWN;
 };
 
 }

--- a/tests/integration/test_system_start_stop_listen/test.py
+++ b/tests/integration/test_system_start_stop_listen/test.py
@@ -174,6 +174,13 @@ def test_all_protocols(started_cluster):
     assert_everything_works()
 
 
+def test_threads_metrics_for_custom_protocols(started_cluster):
+    # Ensure metrics for custom <protocols> endpoints are reported using enum mapping
+    main_node.query("SYSTEM RELOAD ASYNCHRONOUS METRICS")
+    vals = main_node.query("SELECT groupArray(metric) FROM system.asynchronous_metrics WHERE metric IN ('HTTPThreads','TCPThreads')")
+    assert 'HTTPThreads' in vals
+    assert 'TCPThreads' in vals
+
 def test_except(started_cluster):
     custom_client = Client(main_node.ip_address, 9001, command=cluster.client_bin_path)
     assert_everything_works()


### PR DESCRIPTION
…ot port name

- Add ProtocolMetricsType enum
- Pass metrics type via ProtocolServerAdapter
- Map types to {TCP, TCPSecure, HTTP, HTTPS, Interserver, MySQL, PostgreSQL, gRPC, Prometheus, Keeper}
- Update server creation to set metrics type for default and <protocols> endpoints
- Add integration assertion for HTTPThreads/TCPThreads in protocols config

Fixes #80759

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
